### PR TITLE
BUG-1910 Garage Door events being duplicated (#60782)

### DIFF
--- a/devicetypes/smartthings/smartsense-garage-door-sensor-button.src/smartsense-garage-door-sensor-button.groovy
+++ b/devicetypes/smartthings/smartsense-garage-door-sensor-button.src/smartsense-garage-door-sensor-button.groovy
@@ -18,7 +18,7 @@
 metadata {
 	definition (name: "SmartSense Garage Door Sensor Button", namespace: "smartthings", author: "SmartThings") {
 		capability "Three Axis"
-		capability "Garage Door Control"
+		capability "Door Control"
 		capability "Contact Sensor"
 		capability "Actuator"
 		capability "Acceleration Sensor"

--- a/devicetypes/smartthings/testing/simulated-garage-door-opener.src/simulated-garage-door-opener.groovy
+++ b/devicetypes/smartthings/testing/simulated-garage-door-opener.src/simulated-garage-door-opener.groovy
@@ -16,8 +16,7 @@
 metadata {
 	definition (name: "Simulated Garage Door Opener", namespace: "smartthings/testing", author: "SmartThings") {
 		capability "Actuator"
-		capability "Door Control"
-        capability "Garage Door Control"
+        capability "Door Control"
 		capability "Contact Sensor"
 		capability "Refresh"
 		capability "Sensor"

--- a/devicetypes/smartthings/zwave-garage-door-opener.src/zwave-garage-door-opener.groovy
+++ b/devicetypes/smartthings/zwave-garage-door-opener.src/zwave-garage-door-opener.groovy
@@ -17,7 +17,6 @@ metadata {
 	definition (name: "Z-Wave Garage Door Opener", namespace: "smartthings", author: "SmartThings", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, ocfDeviceType: "oic.d.garagedoor") {
 		capability "Actuator"
 		capability "Door Control"
-		capability "Garage Door Control"
 		capability "Health Check"
 		capability "Contact Sensor"
 		capability "Refresh"


### PR DESCRIPTION
* BUG-1910 Garage Door events being duplicated

The Garage Door Control and Door Control capabilities are largely redundandant with each other. We should just be able to remove the Door Control capability.

* Garage Door Control is the actual deprecated capability.